### PR TITLE
Require STS credentials for shadow access

### DIFF
--- a/lib/anthbot/constants.js
+++ b/lib/anthbot/constants.js
@@ -3,16 +3,6 @@
 const DEFAULT_IOT_REGION = 'us-east-1';
 const DEFAULT_IOT_ENDPOINT = 'a2bhy9nr7jkgaj-ats.iot.us-east-1.amazonaws.com';
 const IOT_ENDPOINT_TEMPLATE = 'a2bhy9nr7jkgaj-ats.iot.{region}.amazonaws.com';
-const CN_NORTHWEST_IOT_ENDPOINT = 'a2iw0czxjowiip-ats.iot.cn-northwest-1.amazonaws.com.cn';
-// Anthbot's mobile apps fall back to these vendor-side SigV4 signing values when
-// the cloud API does not return temporary IoT credentials. They are not user
-// secrets or account tokens and are only used to sign anonymous shadow requests.
-const AWS_ACCESS_KEY_DEFAULT = 'AKIAV2C4RVIAOLEXB545';
-const AWS_SECRET_KEY_DEFAULT = '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';
-const AWS_ACCESS_KEY_CN = 'AKIAWJ3KIT7IV6AHMJ5V';
-const AWS_SECRET_KEY_CN = '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';
-const AWS_ACCESS_KEY_CN_NORTHWEST = 'AKIAYVWVSSRF7W5YWI74';
-const AWS_SECRET_KEY_CN_NORTHWEST = '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';
 
 const MODEL_NAME_BY_CATEGORY = {
     'Genie 600': 'Anthbot Genie 600',
@@ -65,13 +55,6 @@ const ROBOT_STATUS_BY_CODE = [
 const M_SERIES_MODEL_PATTERN = /\bM(?:5|9)\b/i;
 
 module.exports = {
-    AWS_ACCESS_KEY_CN,
-    AWS_ACCESS_KEY_CN_NORTHWEST,
-    AWS_ACCESS_KEY_DEFAULT,
-    AWS_SECRET_KEY_CN,
-    AWS_SECRET_KEY_CN_NORTHWEST,
-    AWS_SECRET_KEY_DEFAULT,
-    CN_NORTHWEST_IOT_ENDPOINT,
     DEFAULT_IOT_ENDPOINT,
     DEFAULT_IOT_REGION,
     IOT_ENDPOINT_TEMPLATE,

--- a/lib/anthbot/shadow-client.js
+++ b/lib/anthbot/shadow-client.js
@@ -2,18 +2,7 @@
 
 const crypto = require('node:crypto');
 
-const {
-    AWS_ACCESS_KEY_CN,
-    AWS_ACCESS_KEY_CN_NORTHWEST,
-    AWS_ACCESS_KEY_DEFAULT,
-    AWS_SECRET_KEY_CN,
-    AWS_SECRET_KEY_CN_NORTHWEST,
-    AWS_SECRET_KEY_DEFAULT,
-    CN_NORTHWEST_IOT_ENDPOINT,
-    DEFAULT_IOT_ENDPOINT,
-    DEFAULT_IOT_REGION,
-    IOT_ENDPOINT_TEMPLATE,
-} = require('./constants');
+const { DEFAULT_IOT_ENDPOINT, DEFAULT_IOT_REGION, IOT_ENDPOINT_TEMPLATE } = require('./constants');
 const { AnthbotGenieError, asInteger, firstPresent, isMSeriesModel } = require('./utils');
 
 /** @typedef {[requestUri: string, includeSdkHeaders: boolean, canonicalUriOverride: string | null, signContentLength: boolean]} PublishAttempt */
@@ -132,14 +121,7 @@ class AnthbotShadowApiClient {
         if (typeof this.iotCredentials?.accessKeyId === 'string' && this.iotCredentials.accessKeyId) {
             return this.iotCredentials.accessKeyId;
         }
-        // Anthbot accepts the same bundled fallback signing material used by the mobile apps.
-        if (this.iotEndpoint === CN_NORTHWEST_IOT_ENDPOINT) {
-            return AWS_ACCESS_KEY_CN_NORTHWEST;
-        }
-        if (this.signingRegion.startsWith('cn')) {
-            return AWS_ACCESS_KEY_CN;
-        }
-        return AWS_ACCESS_KEY_DEFAULT;
+        throw new AnthbotGenieError('Temporary IoT credentials are required for shadow access');
     }
 
     /** Get the active AWS secret key for SigV4 request signing. */
@@ -147,13 +129,7 @@ class AnthbotShadowApiClient {
         if (typeof this.iotCredentials?.secretAccessKey === 'string' && this.iotCredentials.secretAccessKey) {
             return this.iotCredentials.secretAccessKey;
         }
-        if (this.iotEndpoint === CN_NORTHWEST_IOT_ENDPOINT) {
-            return AWS_SECRET_KEY_CN_NORTHWEST;
-        }
-        if (this.signingRegion.startsWith('cn')) {
-            return AWS_SECRET_KEY_CN;
-        }
-        return AWS_SECRET_KEY_DEFAULT;
+        throw new AnthbotGenieError('Temporary IoT credentials are required for shadow access');
     }
 
     /**

--- a/main.js
+++ b/main.js
@@ -324,15 +324,9 @@ class AnthbotGenieAdapter extends AdapterBase {
                 device,
                 objectRoot,
                 region,
-                shadowClient: new AnthbotShadowApiClient({
-                    http: this.http,
-                    serialNumber: device.serialNumber,
-                    regionName: region.regionName,
-                    iotEndpoint: region.iotEndpoint,
-                    accountClient: this.cloudClient,
-                    iotCredentials: region.iotCredentials,
-                    deviceModel: device.model,
-                }),
+                shadowClient: region.iotCredentials
+                    ? this.buildShadowClient(device, region, region.iotCredentials)
+                    : null,
                 iotCredentials: region.iotCredentials,
                 areaDefinition: existing?.areaDefinition || {},
                 lastAreaTime: existing?.lastAreaTime || null,
@@ -389,7 +383,7 @@ class AnthbotGenieAdapter extends AdapterBase {
             iotEndpoint = iotCredentials.endpoint || iotEndpoint;
         } catch (error) {
             this.log.warn(
-                `Failed to fetch temporary IoT credentials for ${device.serialNumber}, using bundled fallback signing material: ${error.message}`,
+                `Failed to fetch temporary IoT credentials for ${device.serialNumber}; shadow access is unavailable until STS succeeds again: ${error.message}`,
             );
         }
 
@@ -456,6 +450,11 @@ class AnthbotGenieAdapter extends AdapterBase {
 
     async refreshDevice(context) {
         await this.ensureDeviceIotCredentials(context);
+        if (!context.shadowClient) {
+            throw new AnthbotGenieError(
+                `Skipping ${context.device.serialNumber}: temporary IoT credentials are unavailable for shadow access`,
+            );
+        }
         const propertyState = await context.shadowClient.getShadowReportedState();
         let serviceState = {};
         try {
@@ -501,27 +500,40 @@ class AnthbotGenieAdapter extends AdapterBase {
 
     async ensureDeviceIotCredentials(context) {
         if (
+            context.shadowClient &&
             context.iotCredentials &&
             (!context.iotCredentials.expiresAt || context.iotCredentials.expiresAt - Date.now() > 60000)
         ) {
             return;
         }
-        const iotCredentials = await this.cloudClient.getDeviceIotCredentials(context.device.serialNumber);
-        context.iotCredentials = iotCredentials;
-        context.region = {
-            ...context.region,
-            regionName: iotCredentials.regionName || context.region.regionName,
-            iotEndpoint: iotCredentials.endpoint || context.region.iotEndpoint,
-            iotCredentials,
-        };
-        context.shadowClient = new AnthbotShadowApiClient({
+        try {
+            const iotCredentials = await this.cloudClient.getDeviceIotCredentials(context.device.serialNumber);
+            context.iotCredentials = iotCredentials;
+            context.region = {
+                ...context.region,
+                regionName: iotCredentials.regionName || context.region.regionName,
+                iotEndpoint: iotCredentials.endpoint || context.region.iotEndpoint,
+                iotCredentials,
+            };
+            context.shadowClient = this.buildShadowClient(context.device, context.region, iotCredentials);
+        } catch (error) {
+            context.iotCredentials = null;
+            context.shadowClient = null;
+            throw new AnthbotGenieError(
+                `Temporary IoT credentials are unavailable for ${context.device.serialNumber}; shadow access is disabled until the STS endpoint recovers: ${error.message}`,
+            );
+        }
+    }
+
+    buildShadowClient(device, region, iotCredentials) {
+        return new AnthbotShadowApiClient({
             http: this.http,
-            serialNumber: context.device.serialNumber,
-            regionName: context.region.regionName,
-            iotEndpoint: context.region.iotEndpoint,
+            serialNumber: device.serialNumber,
+            regionName: region.regionName,
+            iotEndpoint: region.iotEndpoint,
             accountClient: this.cloudClient,
             iotCredentials,
-            deviceModel: context.device.model,
+            deviceModel: device.model,
         });
     }
 

--- a/test/unit/anthbot/clients.test.js
+++ b/test/unit/anthbot/clients.test.js
@@ -5,6 +5,12 @@ const assert = require("node:assert/strict");
 const { AnthbotCloudApiClient, AnthbotShadowApiClient } = require("../../../lib/anthbot");
 
 describe("lib/anthbot clients", () => {
+    const tempCredentials = {
+        accessKeyId: "ASIA123",
+        secretAccessKey: "secret",
+        sessionToken: "session",
+    };
+
     it("keeps M-series param_set command payloads sparse when no cutter height is involved", async () => {
         const payloads = [];
         const client = new AnthbotShadowApiClient({
@@ -22,6 +28,7 @@ describe("lib/anthbot clients", () => {
             regionName: "eu-central-1",
             iotEndpoint: "a.example.iot.eu-central-1.amazonaws.com",
             deviceModel: "Anthbot M5",
+            iotCredentials: tempCredentials,
         });
 
         await client.publishServiceCommand({
@@ -157,11 +164,7 @@ describe("lib/anthbot clients", () => {
             serialNumber: "SERIAL123",
             regionName: "eu-central-1",
             iotEndpoint: "a.example.iot.eu-central-1.amazonaws.com",
-            iotCredentials: {
-                accessKeyId: "ASIA123",
-                secretAccessKey: "secret",
-                sessionToken: "session",
-            },
+            iotCredentials: tempCredentials,
         });
 
         await client.getNamedShadowReportedState("property");
@@ -172,20 +175,11 @@ describe("lib/anthbot clients", () => {
         assert.match(requests[0].options.headers.Authorization, /SignedHeaders=.*x-amz-security-token/);
     });
 
-    it("falls back to bundled signing material when temporary credentials are unavailable", async () => {
-        const requests = [];
+    it("requires temporary credentials for shadow access", async () => {
         const client = new AnthbotShadowApiClient({
             http: {
-                get: async (url, options) => {
-                    requests.push({ url, options });
-                    return {
-                        status: 200,
-                        data: {
-                            state: {
-                                reported: { ok: true },
-                            },
-                        },
-                    };
+                get: async () => {
+                    throw new Error("request should not be sent without temporary credentials");
                 },
             },
             serialNumber: "SERIAL123",
@@ -193,11 +187,10 @@ describe("lib/anthbot clients", () => {
             iotEndpoint: "a2bhy9nr7jkgaj-ats.iot.us-east-1.amazonaws.com",
         });
 
-        await client.getNamedShadowReportedState("property");
-
-        assert.equal(requests.length, 1);
-        assert.match(requests[0].options.headers.Authorization, /Credential=AKIAV2C4RVIAOLEXB545\//);
-        assert.equal(requests[0].options.headers["x-amz-security-token"], undefined);
+        await assert.rejects(
+            client.getNamedShadowReportedState("property"),
+            /Temporary IoT credentials are required for shadow access/,
+        );
     });
 
     it("refreshes IoT credentials once after a shadow 403", async () => {
@@ -273,6 +266,7 @@ describe("lib/anthbot clients", () => {
             regionName: "eu-central-1",
             iotEndpoint: "a.example.iot.eu-central-1.amazonaws.com",
             deviceModel: "Anthbot M5",
+            iotCredentials: tempCredentials,
         });
 
         assert.deepEqual(await client.getServiceReportedState(), { cmd: "find_robot" });
@@ -297,6 +291,7 @@ describe("lib/anthbot clients", () => {
             regionName: "eu-central-1",
             iotEndpoint: "a.example.iot.eu-central-1.amazonaws.com",
             deviceModel: "Anthbot M5",
+            iotCredentials: tempCredentials,
         });
 
         await client.publishServiceCommand({
@@ -348,6 +343,7 @@ describe("lib/anthbot clients", () => {
             regionName: "eu-central-1",
             iotEndpoint: "a.example.iot.eu-central-1.amazonaws.com",
             deviceModel: "Anthbot Genie 600",
+            iotCredentials: tempCredentials,
         });
 
         await client.publishServiceCommand({


### PR DESCRIPTION
## Summary
Remove the dead AWS shadow-signing fallback and make the STS failure mode explicit.

## What changed
- remove the static AWS fallback signing keys
- require temporary IoT STS credentials for shadow access
- make STS failures explicit at the adapter layer instead of constructing a non-working shadow client
- update client tests to reflect the supported credential flow

## Validation
- `npm run lint`
- `npm run check`
- `npm test`

## Notes
The old fallback signing path was verified live and returned `403 Forbidden`, while the temporary IoT credential path still works. Keeping the fallback would therefore preserve dead code, not real availability.
